### PR TITLE
Fix make trigger extend dolibarr triggers

### DIFF
--- a/core/boxes/sendinblue_box.php
+++ b/core/boxes/sendinblue_box.php
@@ -62,7 +62,6 @@ class sendinbluebox extends ModeleBoxes
 
         $this->max = $max;
 
-        //include_once DOL_DOCUMENT_ROOT . "/sendinblue/class/sendinblue.class.php";
 
         $text = $langs->trans("MyBoxDescription", $max);
         $this->info_box_head = array(

--- a/core/triggers/interface_99_modsendinblue_sendinbluetrigger.class.php
+++ b/core/triggers/interface_99_modsendinblue_sendinbluetrigger.class.php
@@ -33,11 +33,8 @@
 /**
  * Trigger class
  */
-class Interfacesendinbluetrigger
+class Interfacesendinbluetrigger extends DolibarrTriggers
 {
-
-    private $db;
-
     /**
      * Constructor
      *
@@ -101,7 +98,7 @@ class Interfacesendinbluetrigger
 
     /**
      * Function called when a Dolibarrr business event is done.
-     * All functions "run_trigger" are triggered if file
+     * All functions "runTrigger" are triggered if file
      * is inside directory core/triggers
      *
      * 	@param		string		$action		Event action code
@@ -111,7 +108,7 @@ class Interfacesendinbluetrigger
      * 	@param		conf		$conf		Object conf
      * 	@return		int						<0 if KO, 0 if no triggered ran, >0 if OK
      */
-    public function run_trigger($action, $object, $user, $langs, $conf)
+    public function runTrigger($action, $object, $user, $langs, $conf)
     {
         // Put here code you want to execute when a Dolibarr business events occurs.
         // Data and type of action are stored into $object and $action

--- a/sendinblue/list_click.php
+++ b/sendinblue/list_click.php
@@ -172,8 +172,7 @@ print_barre_liste($title, $page, $_SERVER['PHP_SELF'], $option, $sortfield, $sor
 print '<form method="post" action="' . $_SERVER ['PHP_SELF'] . '" name="search_form">' . "\n";
 
 print '<div class="liste_titre">';
-print $langs->trans('DateValid');
-print $langs->trans('Month') . ':<input class="flat" type="text" size="4" name="search_month" value="' . $search_month . '">';
+print $langs->trans('Month') . ': '.$formother->select_month($search_month, 'search_month');
 print $langs->trans('Year') . ':' . $formother->selectyear($search_year ? $search_year : - 1, 'search_year', 1, 20, 5);
 
 


### PR DESCRIPTION
# FIX
- Change the subtotal module trigger class definition to avoid error message from Dolibarr
- Rename `run_trigger` to `runTrigger`
- Remove the declaration of the `$db` field if present (already declared as `protected` in the parent class)