### PR TITLE
FIX : missing GETPOST check parameters (none)

### DIFF
--- a/admin/sendinblue_setup.php
+++ b/admin/sendinblue_setup.php
@@ -56,7 +56,7 @@ $refreshButtonPressed = isset($_SERVER['HTTP_CACHE_CONTROL']) && ($_SERVER['HTTP
  */
 if ($action == 'setvar') {
 
-	$res = dolibarr_set_const($db, 'SENDINBLUE_API_KEY', GETPOST('SENDINBLUE_API_KEY'), 'chaine', 0, '', $conf->entity);
+	$res = dolibarr_set_const($db, 'SENDINBLUE_API_KEY', GETPOST('SENDINBLUE_API_KEY', 'none'), 'chaine', 0, '', $conf->entity);
 	if (! $res > 0) {
 		$error ++;
 	}
@@ -96,7 +96,7 @@ if ($action == 'setvar') {
 	}
 }
 if ($action == 'activsendinblue') {
-	dolibarr_set_const($db, "SEND_BY_SENDINBLUE", GETPOST("value"), 'chaine', 0, '', $conf->entity);
+	dolibarr_set_const($db, "SEND_BY_SENDINBLUE", GETPOST("value", 'none'), 'chaine', 0, '', $conf->entity);
 }
 if ($action == 'activsendinblue' && $conf->global->SEND_BY_SENDINBLUE && ! $refreshButtonPressed) {
 	$res = dolibarr_set_const($db, "SENDINBLUE_MAIL_SENDMODE_STD", $conf->global->MAIN_MAIL_SENDMODE, 'chaine', 0, '', $conf->entity);

--- a/class/actions_sendinblue.class.php
+++ b/class/actions_sendinblue.class.php
@@ -257,7 +257,7 @@ class Actionssendinblue
 		}*/
 		if (in_array('contactcard', $hookmanager->contextarray)) {
 
-			if ($action == 'edit' && GETPOST('action') == 'update') {
+			if ($action == 'edit' && GETPOST('action', 'alpha') == 'update') {
 				echo '<div id="dialog" title="' . $langs->trans('UpdateSendinBlueObject') . '">';
 				echo $langs->trans('ConfirmUpdateSendinBlueObject');
 				echo "</div>";
@@ -307,7 +307,7 @@ class Actionssendinblue
 			$langs->load("user");
 
 			// Change substitution array
-			
+
 
 			if ($action == '' || $action == 'valid') {
 				$error_sendinblue_control = 0;
@@ -346,13 +346,13 @@ class Actionssendinblue
 				dol_include_once('/sendinblue/class/dolsendinblue.class.php');
 				$sendinblue = new DolSendinBlue($this->db);
 				$contact = new Contact($db);
-				$contact->fetch(GETPOST('id'));
+				$contact->fetch(GETPOST('id', 'int'));
 				$result=$sendinblue->getListForEmail($contact->email);
 				if ($result != - 1
 						&& array_key_exists('total_items', $result)
 						&& $result['total_items']>0
 						&& $action == 'update'
-						&& $contact->email != GETPOST('email')) {
+						&& $contact->email != GETPOST('email', 'custom', 0, FILTER_SANITIZE_EMAIL)) {
 					$action = 'edit';
 				}
 			}

--- a/class/actions_sendinblue.class.php
+++ b/class/actions_sendinblue.class.php
@@ -352,7 +352,7 @@ class Actionssendinblue
 						&& array_key_exists('total_items', $result)
 						&& $result['total_items']>0
 						&& $action == 'update'
-						&& $contact->email != GETPOST('email', 'custom', 0, FILTER_SANITIZE_EMAIL)) {
+						&& $contact->email != ((floatval(DOL_VERSION) > 4) ? GETPOST('email', 'custom', 0, FILTER_SANITIZE_EMAIL) : GETPOST('email', 'none'))) {
 					$action = 'edit';
 				}
 			}

--- a/index.php
+++ b/index.php
@@ -42,7 +42,7 @@ if (! $res) {
 require_once 'class/dolsendinblue.class.php';
 
 $action=GETPOST('action','alpha');
-$confirm = GETPOST('confirm');
+$confirm = GETPOST('confirm', 'none');
 
 if ($action=='updateallcampagin_confirm' && $confirm='yes' && $user->rights->mailing->creer) {
 	$sendinblue= new DolSendinblue($db);
@@ -91,7 +91,7 @@ if (is_array($sendinblue->listcampaign_lines) && count($sendinblue->listcampaign
 		$var=!$var;
 		$sendinblue_dolibarr= new DolSendinBlue($db);
 		if (!empty($line['id'])) {
-			
+
 			$result=$sendinblue_dolibarr->fetch_by_sendinblueid($line['id']);
 			if ($result<0) {
 				setEventMessage($sendinblue_dolibarr->error,'errors');
@@ -104,7 +104,7 @@ if (is_array($sendinblue->listcampaign_lines) && count($sendinblue->listcampaign
 			$link = "https://my.sendinblue.com/camp/report/id/".$line['id'];
 			$title = $line['campaign_name'];
 		}
-		
+
 		print "<tr " . $bc[$var] . ">";
 		print '<td><a target="_blanck" href='.$link.'>'.$title.'</a></td>';
 		print '<td>';

--- a/script/interface.php
+++ b/script/interface.php
@@ -33,7 +33,7 @@ $get=GETPOST('get', 'none');
 $set=GETPOST('set', 'none');
 
 if (empty($listid)) $listid = GETPOST('listid', 'none');
-if (empty($fk_mailing)) $fk_mailing = GETPOST('fk_mailing', 'int');
+if (empty($fk_mailing)) $fk_mailing = (int)GETPOST('fk_mailing', 'int');
 
 if (empty($listid)) return __out('listid param missing');
 if (empty($fk_mailing)) return __out('fk_mailing param missing');

--- a/script/interface.php
+++ b/script/interface.php
@@ -5,10 +5,10 @@ $sapi_type = php_sapi_name();
 if (substr($sapi_type, 0, 3) == 'cli')
 {
 	@set_time_limit(0);
-	
+
 	define('INC_FROM_CRON_SCRIPT', 1);
 	chdir(dirname(__FILE__));
-	
+
 	// get params
 	foreach($argv as $key => $val)
 	{
@@ -29,11 +29,11 @@ if (!empty($fk_user) && $user->id != $fk_user)
 }
 
 
-$get=GETPOST('get');
-$set=GETPOST('set');
+$get=GETPOST('get', 'none');
+$set=GETPOST('set', 'none');
 
-if (empty($listid)) $listid = GETPOST('listid');
-if (empty($fk_mailing)) $fk_mailing = GETPOST('fk_mailing');
+if (empty($listid)) $listid = GETPOST('listid', 'none');
+if (empty($fk_mailing)) $fk_mailing = GETPOST('fk_mailing', 'int');
 
 if (empty($listid)) return __out('listid param missing');
 if (empty($fk_mailing)) return __out('fk_mailing param missing');
@@ -62,7 +62,7 @@ else
 
 switch ($get) {
 	case 'pidIsRunning':
-		$TSendInBluePid = GETPOST('TSendInBluePid');
+		$TSendInBluePid = GETPOST('TSendInBluePid', 'none');
 		if (!empty($TSendInBluePid))
 		{
 			foreach ($TSendInBluePid as $pid)
@@ -73,14 +73,14 @@ switch ($get) {
 					__out(false);
 					exit;
 				}
-				
+
 				unset($_SESSION['SENDINBLUE_PID_ACTIVE'][$fk_mailing][$listid][$pid]);
 			}
 		}
-		
+
 		__out(true);
 		exit;
-		
+
 		break;
 }
 
@@ -88,10 +88,10 @@ switch ($set) {
 	case 'export':
 		$script = dol_buildpath('/sendinblue/script/interface.php', 0);
 		$params = 'async_action=export listid='.$listid.' fk_mailing='.$fk_mailing.' fk_user='.$user->id;
-		
+
 		$pid = exec('php '.$script.' '.$params.' > /dev/null 2>&1 & echo $!;');
 		$_SESSION['SENDINBLUE_PID_ACTIVE'][$fk_mailing][$listid][$pid] = $pid;
-		
+
 		__out($pid);
 		exit;
 
@@ -99,13 +99,13 @@ switch ($set) {
 	case 'import':
 		$script = dol_buildpath('/sendinblue/script/interface.php', 0);
 		$params = 'async_action=import listid='.$listid.' fk_mailing='.$fk_mailing.' fk_user='.$user->id;
-		
+
 		$pid = exec('php '.$script.' '.$params.' > /dev/null 2>&1 & echo $!;');
 		$_SESSION['SENDINBLUE_PID_ACTIVE'][$fk_mailing][$listid][$pid] = $pid;
-		
+
 		__out($pid);
 		exit;
-		
+
 		break;
 }
 

--- a/sendinblue/destinaries_list.php
+++ b/sendinblue/destinaries_list.php
@@ -46,7 +46,7 @@ $langs->load("sendinblue@sendinblue");
 $productid = GETPOST('productid', 'int');
 $action = GETPOST('action', 'alpha');
 $type = GETPOST('type', 'alpha');
-$nameList = GETPOST('nameList');
+$nameList = GETPOST('nameList', 'none');
 
 //Set page var
 $refemail=false;
@@ -79,14 +79,14 @@ if ($action=='associateconfirm') {
 	} else {
 		$listid=GETPOST('selectlist','alpha');
 	}
-	$emailtoadd=GETPOST('emailtoadd');
+	$emailtoadd=GETPOST('emailtoadd', 'custom', 0, FILTER_SANITIZE_EMAIL);
 	if (empty($listid)) {
 		setEventMessage($langs->trans("ErrorFieldRequired",$langs->transnoentities("SendinBlueUpdateExistingList")),'errors');
 		$error++;
 	}
-	
 
-	
+
+
 
 	if (!is_array($emailtoadd)) {
 		setEventMessage($langs->trans("ErrorFieldRequired",$langs->transnoentities("EMail")),'errors');
@@ -99,11 +99,11 @@ if ($action=='associateconfirm') {
 		$result=$sendinblue->addEmailToList($listid,$emailtoadd);
 		if ($result<0) {
 			setEventMessage($sendinblue->error,'errors');
-		} 
+		}
 	}else {
 		$action='associate';
 	}
-	
+
 }
 
 $result=$sendinblue->getListDestinaries();
@@ -123,15 +123,15 @@ if (!empty($conf->global->SENDINBLUE_API_KEY)) {
 
 	//View associate
 	if ($action=='associate') {
-		
+
 		print_fiche_titre($langs->trans('SendinBlueDestListAction'));
-		
+
 		print '<form name="formsoc" method="post" action="'.$_SERVER["PHP_SELF"].'" enctype="multipart/form-data">';
 		print '<input type="hidden" value="associateconfirm" name="action">';
 		print '<input type="hidden" value="'.$_SESSION['newtoken'].'" name="token">';
 		print '<input type="hidden" value="'.$productid.'" name="productid">';
 		print '<input type="hidden" value="'.$type.'" name="type">';
-	
+
 		print '<table class="border" width="100%">';
 		print '<tr class="liste_titre">';
 		print '<td>'.$langs->trans('EMail').'</td>';
@@ -146,11 +146,11 @@ if (!empty($conf->global->SENDINBLUE_API_KEY)) {
 		}
 
 		if (is_array($sendinblue->email_lines) && count($sendinblue->email_lines)>0) {
-			
+
 			$refemail=true;
-			
+
 			foreach ($sendinblue->email_lines as $line) {
-					
+
 				$var=!$var;
 
 				print "<tr " . $bc[$var] . ">";
@@ -175,10 +175,10 @@ if (!empty($conf->global->SENDINBLUE_API_KEY)) {
 		}
 
 		print '</table>';
-		
-		
+
+
 		if ($refemail) {
-			
+
 			print '<center><br>';
 			print $langs->trans('SendinBlueUpdateExistingList');
 			$events=array();
@@ -187,26 +187,26 @@ if (!empty($conf->global->SENDINBLUE_API_KEY)) {
 			}
 			print $formsendinblue->select_sendinbluelist('selectlist',1,'',0,$events);
 			print '<br>'.$langs->trans('SendinBlueOr');
-			
+
 			print ' '.$langs->trans('SendinBlueCreateList').' : ';
 		//print '&nbsp;<a href="https://my.sendinblue.com/lists" target="_blanck" >'.$langs->trans('SendinBlueNewListName').'</a>';
-		
+
 			print '&nbsp; <input type="text" name="nameList"></input>';
 			print '</td></tr>';
 			print '<div id="blocksegement" >';
 		//	print $langs->trans('SendinBlueUpdateExistingSegments');
 			//print $formsendinblue->select_sendinbluesegement(0,'segmentlist');
 			//print '<br>'.$langs->trans('SendinBlueOr');
-				
+
 			//print '&nbsp;'.$langs->trans('SendinBlueNewSegmentName').': <input type="text" class="flat" size="8" maxsize="50" name="segmentname">';
-			
+
 			print '<br><input type="submit" class="button" value="'.$langs->trans('Save').'"/>';
 			print '</div>';
 			print '</center>';
-					
+
 		}
 	}
-	
+
 	print '<form>';
 
 	print '<BR>';
@@ -222,7 +222,7 @@ if (!empty($conf->global->SENDINBLUE_API_KEY)) {
 	$sendinbluesegment= new DolSendinBlue($db);
 	if (is_array($sendinblue->listdest_lines) && count($sendinblue->listdest_lines)>0) {
 		foreach($sendinblue->listdest_lines['data'] as $dest_line) {
-	
+
 			$var=!$var;
 			print "<tr " . $bc[$var] . ">";
 			print '<td><a target="_blanck" href="https://my.sendinblue.com/users/list/id/'.$dest_line['id'].'">'.$dest_line['name'].'</a></td>';
@@ -230,24 +230,24 @@ if (!empty($conf->global->SENDINBLUE_API_KEY)) {
 			print '<td>'.$dest_line['total_subscribers'].'</td>';
 			print '<td>'.$dest_line['entered'].'</td>';
 			print '</tr>';
-			
+
 			/*$result=$sendinbluesegment->getListSegmentDestinaries($dest_line['id']);
 			if ($result<0) {
 				setEventMessage($sendinbluesegment->error,'errors');
 			}
-			
+
 			if (is_array($sendinbluesegment->listsegment_lines) && count($sendinbluesegment->listsegment_lines)>0) {
 				foreach($sendinbluesegment->listsegment_lines as $seg_line) {
-					
+
 					print "<tr " . $bc[$var] . ">";
 					print '<td>&nbsp;&nbsp;&nbsp;&nbsp;'.$langs->trans('SendinBlueSegment').' : '.$seg_line['name'].'</td>';
 					print '<td>'.$seg_line['member_count'].'</td>';
 					print '<td>'.$seg_line['created_at'].'</td>';
 					print '</tr>';
 				}
-				
+
 			}*/
-	
+
 		}
 	}
 	else {

--- a/sendinblue/list_click.php
+++ b/sendinblue/list_click.php
@@ -64,7 +64,7 @@ $search_year = GETPOST('search_year', 'int');
 $sortorder = GETPOST('sortorder', 'alpha');
 $sortfield = GETPOST('sortfield', 'alpha');
 $page = GETPOST('page', 'int');
-$contact_id=GETPOST('contactid', 'int');
+$contact_id=(int)GETPOST('contactid', 'int');
 
 
 if (empty($search_year)) {

--- a/sendinblue/list_click.php
+++ b/sendinblue/list_click.php
@@ -64,7 +64,7 @@ $search_year = GETPOST('search_year', 'int');
 $sortorder = GETPOST('sortorder', 'alpha');
 $sortfield = GETPOST('sortfield', 'alpha');
 $page = GETPOST('page', 'int');
-$contact_id=GETPOST('contactid');
+$contact_id=GETPOST('contactid', 'int');
 
 
 if (empty($search_year)) {
@@ -95,7 +95,7 @@ if ($page == - 1) {
 
 $offset = $conf->liste_limit * $page;
 
-if (GETPOST("button_removefilter_x") || GETPOST("button_removefilter")) {
+if (GETPOST("button_removefilter_x", 'none') || GETPOST("button_removefilter", 'none')) {
 	$search_month = '';
 	$search_year = '';
 	$search_title='';
@@ -157,7 +157,7 @@ $form = new Form($db);
  */
 
 if (empty($conf->global->MAIN_DISABLE_FULL_SCANLIST)) {
-	
+
 	$nbtotalofrecords = $sendinblueactivities->getEmailcontactActivitesClick($sortorder, $sortfield, 0, 0, $filter);
 }
 
@@ -203,7 +203,7 @@ $sendinbluestatic = new DolSendinBlue($db);
 $contact_array=array();
 if (is_array($sendinblueactivities->contactemail_clickactivity) && count($sendinblueactivities->contactemail_clickactivity) > 0) {
 	foreach ( $sendinblueactivities->contactemail_clickactivity as $activites ) {
-		
+
 		if (!array_key_exists($activites->contactid, $contact_array) && !empty($activites->contactid)) {
 			$result=$contact->fetch($activites->contactid);
 			if ($result<0) {
@@ -211,8 +211,8 @@ if (is_array($sendinblueactivities->contactemail_clickactivity) && count($sendin
 			} else {
 				$contact_array[$activites->contactid]=$contact->getNomUrl();
 			}
-		} 
-		
+		}
+
 		if (is_array($activites->activites) && count($activites->activites) > 0) {
 			foreach ( $activites->activites as $act ) {
 				$var = ! $var;
@@ -227,7 +227,7 @@ if (is_array($sendinblueactivities->contactemail_clickactivity) && count($sendin
 				print dol_print_date($activites->datec);
 				print '</td>';
 				print '<td>';
-				print $activites->email;	
+				print $activites->email;
 				print '</td>';
 				print '<td>';
 				print $activites->socname;
@@ -238,7 +238,7 @@ if (is_array($sendinblueactivities->contactemail_clickactivity) && count($sendin
 				print '<td>';
 				print $contact_array[$activites->contactid];
 				print '</td>';
-				
+
 				print '</tr>';
 			}
 		}

--- a/sendinblue/list_open.php
+++ b/sendinblue/list_open.php
@@ -85,7 +85,7 @@ $search_title=GETPOST('search_title','alpha');
 $search_mail=GETPOST('search_mail','alpha');
 $search_link=GETPOST('search_link','alpha');
 $search_socname=GETPOST('search_socname','alpha');
-$contact_id=GETPOST('contactid');
+$contact_id=GETPOST('contactid', 'int');
 
 if ($page == - 1) {
 	$page = 0;
@@ -93,7 +93,7 @@ if ($page == - 1) {
 
 $offset = $conf->liste_limit * $page;
 
-if (GETPOST("button_removefilter_x") || GETPOST("button_removefilter")) {
+if (GETPOST("button_removefilter_x", 'none') || GETPOST("button_removefilter", 'none')) {
 	$search_month = '';
 	$search_year = '';
 	$search_title='';
@@ -156,7 +156,7 @@ $form = new Form($db);
  */
 
 if (empty($conf->global->MAIN_DISABLE_FULL_SCANLIST)) {
-	
+
 	$nbtotalofrecords = $sendinblueactivities->getEmailcontactActivitesOpen($sortorder, $sortfield, 0, 0, $filter);
 }
 
@@ -202,7 +202,7 @@ $sendinbluestatic = new DolSendinBlue($db);
 $contact_array=array();
 if (is_array($sendinblueactivities->contactemail_clickactivity) && count($sendinblueactivities->contactemail_clickactivity) > 0) {
 	foreach ( $sendinblueactivities->contactemail_clickactivity as $activites ) {
-		
+
 		if (!array_key_exists($activites->contactid, $contact_array) && !empty($activites->contactid)) {
 			$result=$contact->fetch($activites->contactid);
 			if ($result<0) {
@@ -210,8 +210,8 @@ if (is_array($sendinblueactivities->contactemail_clickactivity) && count($sendin
 			} else {
 				$contact_array[$activites->contactid]=$contact->getNomUrl();
 			}
-		} 
-		
+		}
+
 		if (is_array($activites->activites) && count($activites->activites) > 0) {
 			foreach ( $activites->activites as $act ) {
 				$var = ! $var;
@@ -226,7 +226,7 @@ if (is_array($sendinblueactivities->contactemail_clickactivity) && count($sendin
 				print dol_print_date($activites->datec);
 				print '</td>';
 				print '<td>';
-				print $activites->email;	
+				print $activites->email;
 				print '</td>';
 				print '<td>';
 				print $activites->socname;
@@ -237,7 +237,7 @@ if (is_array($sendinblueactivities->contactemail_clickactivity) && count($sendin
 				print '<td>';
 				print $contact_array[$activites->contactid];
 				print '</td>';
-				
+
 				print '</tr>';
 			}
 		}

--- a/sendinblue/list_open.php
+++ b/sendinblue/list_open.php
@@ -85,7 +85,7 @@ $search_title=GETPOST('search_title','alpha');
 $search_mail=GETPOST('search_mail','alpha');
 $search_link=GETPOST('search_link','alpha');
 $search_socname=GETPOST('search_socname','alpha');
-$contact_id=GETPOST('contactid', 'int');
+$contact_id=(int)GETPOST('contactid', 'int');
 
 if ($page == - 1) {
 	$page = 0;

--- a/sendinblue/sendinblue.php
+++ b/sendinblue/sendinblue.php
@@ -42,9 +42,9 @@ $langs->load("mails");
 // Get parameters
 $id = GETPOST('id', 'int');
 $action = GETPOST('action', 'alpha');
-$confirm = GETPOST('confirm');
-$createList = GETPOST('createList');
-$nameList = GETPOST('nameList');
+$confirm = GETPOST('confirm', 'none');
+$createList = GETPOST('createList', 'none');
+$nameList = GETPOST('nameList', 'none');
 
 $error=0;
 
@@ -183,7 +183,7 @@ if ($action == 'createsendinbluecampaign') {
 
 	$result=$sendinblue->createSendinBlueCampaign($user);
 	if ($result<0) {
-		
+
 		setEventMessage($sendinblue->error,'errors');
 	}
 }
@@ -275,9 +275,9 @@ if(!empty($conf->global->SENDINBLUE_API_KEY)){
 		else {
 			if (!empty($sendinblue->sendinblue_listid)) {
 				$result=$sendinblue->getEmailList();
-				
+
 				if ($result<0) {
-					
+
 					setEventMessage($sendinblue->error,'errors');
 				} else {
 					foreach($sendinblue->email_lines as $l){
@@ -309,13 +309,13 @@ if(!empty($conf->global->SENDINBLUE_API_KEY)){
 
 		}else {
 			foreach($email_seg_array as $emailadress){
-				$email_sb_array[]=$emailadress; 
+				$email_sb_array[]=$emailadress;
 			}
 
 			//if count is same compare email by email
 			foreach($email_dol_array as $emailadress) {
 				if (!in_array($emailadress,$email_sb_array)) {
-					
+
 					$warning_destnotsync=true;
 					break;
 				}
@@ -333,7 +333,7 @@ if(!empty($conf->global->SENDINBLUE_API_KEY)){
 } else {
 	$warning_destnotsync=true;
 }
-	
+
 }
 
 
@@ -475,10 +475,10 @@ if ( !empty($conf->global->SENDINBLUE_API_KEY)) {
 				setEventMessage($sendinblue->error,'errors');
 			}
 			if (is_array($sendinblue->listdest_lines) && count($sendinblue->listdest_lines)>0) {
-				
-					
+
+
 				print $sendinblue->listdest_lines['data']['name'];
-				
+
 			}
 		}
 		print '</td></tr>';
@@ -522,10 +522,10 @@ if ( !empty($conf->global->SENDINBLUE_API_KEY)) {
 		print '<form name="formmailing" method="post" action="'.$_SERVER["PHP_SELF"].'?id='.$id.'">';
 		print '<input type="hidden" value="associateconfirm" name="action">';
 		print '<input type="hidden" value="'.$_SESSION['newtoken'].'" name="token">';
-		
+
 		print '<br/><br/>';
 		print '<table class="border tableforfield" width="100%" style="border:1px solid #ccc;padding:5px;">';
-		
+
 		print '<tr class="pair"><td colspan="3"><h3>SendinBlue</h3></td></tr>';
 		print '<tr class="impair"><td width="30%">';
 		print $langs->trans('SendinBlueCreateList');
@@ -534,12 +534,12 @@ if ( !empty($conf->global->SENDINBLUE_API_KEY)) {
 		print '<input type="submit" class="button" name="createList" value="'.$langs->trans('Add').'"/>';
 		print '</td><td>';
 		print '</td></tr>';
-		
+
 		print '</table>';
-		
+
 		print '<br/><br/>';
 		print '<table class="border tableforfield" width="100%" style="border:1px solid #ccc;padding:5px;">';
-		
+
 		print '<tr class="pair"><td colspan="3"><h3>SendinBlue</h3></td></tr>';
 		print '<tr class="pair"><td class="fieldrequired" width="30%">';
 		print $langs->trans('SendinBlueUpdateExistingList');
@@ -552,11 +552,11 @@ if ( !empty($conf->global->SENDINBLUE_API_KEY)) {
 		print '&nbsp;&nbsp;<input type="submit" class="button" name="save" value="'.$langs->trans('Save').'" />';
 		print '</td><td>';
 		print '</td></tr>';
-		
+
 		print '<tr class="impair"><td colspan="3" style="text-align:center">';
 		print img_picto($langs->trans('SendinBlue_SyncLoading'), 'sync_loading.gif@sendinblue', 'id="sendinblue_loading" style="display:none;margin:20px auto 0"');
 		print '</td></tr>';
-		
+
 		print '<tr class="pair">';
 		print '<td style="text-align:right"><input id="bt_send_import" type="button" class="button" onclick="sendInBlueCallImport()" value="'.$langs->trans('SendinBlueImportForm').'" />';
 		print $form->textwithpicto('',$langs->trans('SendinBlueImportFormHelp'));
@@ -659,14 +659,14 @@ if($object->statut == 3){
 		$PDOdb = new TPDOdb;
 		$listeview = new TListviewTBS('graphCampaignActions');
 		$TSum[] = array($langs->transnoentities('unique_views'),$sendinblue->sendinblue_webid['data'][0]['unique_views']);
-		$TSum[] = array($langs->transnoentities('viewed'),$sendinblue->sendinblue_webid['data'][0]['viewed']);	
-		$TSum[] = array($langs->transnoentities('clicked'),$sendinblue->sendinblue_webid['data'][0]['clicked']);	
-		$TSum[] = array($langs->transnoentities('Hard Bounce'),$sendinblue->sendinblue_webid['data'][0]['hard_bounce']);	
-		$TSum[] = array($langs->transnoentities('Soft Bounce'),$sendinblue->sendinblue_webid['data'][0]['soft_bounce']);	
-		$TSum[] = array($langs->transnoentities('unsub'),$sendinblue->sendinblue_webid['data'][0]['unsub']);	
+		$TSum[] = array($langs->transnoentities('viewed'),$sendinblue->sendinblue_webid['data'][0]['viewed']);
+		$TSum[] = array($langs->transnoentities('clicked'),$sendinblue->sendinblue_webid['data'][0]['clicked']);
+		$TSum[] = array($langs->transnoentities('Hard Bounce'),$sendinblue->sendinblue_webid['data'][0]['hard_bounce']);
+		$TSum[] = array($langs->transnoentities('Soft Bounce'),$sendinblue->sendinblue_webid['data'][0]['soft_bounce']);
+		$TSum[] = array($langs->transnoentities('unsub'),$sendinblue->sendinblue_webid['data'][0]['unsub']);
 		$TSum[] = array($langs->transnoentities('mirror_click'),$sendinblue->sendinblue_webid['data'][0]['mirror_click']);
-		$TSum[] = array($langs->transnoentities('complaints'),$sendinblue->sendinblue_webid['data'][0]['complaints']);	
-		
+		$TSum[] = array($langs->transnoentities('complaints'),$sendinblue->sendinblue_webid['data'][0]['complaints']);
+
 		if(!empty($sendinblue->sendinblue_webid['data'][0]['delivered'])){
 			print $listeview->renderArray($PDOdb, $TSum
 			,array(
@@ -678,7 +678,7 @@ if($object->statut == 3){
 			)
 			);
 		}
-		
+
 }
 
 //unset($_SESSION['SENDINBLUE_PID_ACTIVE']);
@@ -691,24 +691,24 @@ if($object->statut == 3){
 <script type="text/javascript">
 	sendInBlueTimer = null;
 	TSendInBluePid = [];
-	<?php 
-	if (!empty($_SESSION['SENDINBLUE_PID_ACTIVE'][$object->id])) { 
+	<?php
+	if (!empty($_SESSION['SENDINBLUE_PID_ACTIVE'][$object->id])) {
 		foreach ($_SESSION['SENDINBLUE_PID_ACTIVE'][$object->id] as $lid => $TPid) {
-			foreach ($TPid as $pid) { 
+			foreach ($TPid as $pid) {
 			?>
 				TSendInBluePid.push(<?php echo $pid; ?>);
 			<?php
-			} 
+			}
 		}
 	}
 	?>
-	
-	
+
+
 	triggerIntervalChecker = function() {
 		$('#bt_send_export').prop('disabled',true);
 		$('#bt_send_import').prop('disabled',true);
 		$('#sendinblue_loading').css('display', 'block');
-		
+
 		sendInBlueTimer = setInterval(function() {
 			var listid = $('#selectlist').val();
 			var fk_mailing = <?php echo $object->id; ?>;
@@ -730,19 +730,19 @@ if($object->statut == 3){
 			});
 		}, 5000);
 	};
-	
+
 	if (TSendInBluePid.length > 0) {
 		triggerIntervalChecker();
 	}
-	
+
 	sendInBlueCallExport = function() {
 		sendInBlueCallAjax('export', '');
 	};
-	
+
 	sendInBlueCallImport = function() {
 		sendInBlueCallAjax('import', '');
 	};
-	
+
 	sendInBlueCallAjax = function(set, get) {
 		var listid = $('#selectlist').val();
 		var fk_mailing = <?php echo $object->id; ?>;
@@ -765,7 +765,7 @@ if($object->statut == 3){
 			}
 		});
 	};
-	
+
 </script>
 <?php
 // End of page

--- a/sendinblue/target.php
+++ b/sendinblue/target.php
@@ -66,13 +66,13 @@ if (! $sortfield) $sortfield="email";
 
 $id=GETPOST('id','int');
 $rowid=GETPOST('rowid','int');
-$action=GETPOST("action");
-$search_lastname=GETPOST("search_lastname");
-$search_firstname=GETPOST("search_firstname");
-$search_email=GETPOST("search_email");
-$search_dest_status=GETPOST('search_dest_status');
-$search_contact=GETPOST('search_contact');
-$search_socname=GETPOST('search_socname');
+$action=GETPOST("action", 'alpha');
+$search_lastname=GETPOST("search_lastname", 'none');
+$search_firstname=GETPOST("search_firstname", 'none');
+$search_email=GETPOST("search_email", 'none');
+$search_dest_status=GETPOST('search_dest_status', 'none');
+$search_contact=GETPOST('search_contact', 'none');
+$search_socname=GETPOST('search_socname', 'none');
 
 // Search modules dirs
 $modulesdir = dolGetModulesDirs('/mailings');
@@ -87,7 +87,7 @@ $formsendinblue = new FormSendinBlue($db);
 
 if ($action == 'add')
 {
-	$module=GETPOST("module");
+	$module=GETPOST("module", 'none');
 	$result=-1;
 
 	$var=true;
@@ -113,7 +113,7 @@ if ($action == 'add')
 
 			// Add targets into database
 			$obj = new $classname($db);
-			
+
 			$result=$obj->add_to_target($id,$filtersarray);
 		}
 	}
@@ -133,25 +133,25 @@ if ($action == 'add')
 	}
 }
 else if($action=='exportlist') {
-    
-    $sql = base64_decode(GETPOST('sql'));
+
+    $sql = base64_decode(GETPOST('sql', 'none'));
     $resql=$db->query($sql);
-    
+
     $first = true;
     $f1  =tmpfile();
     $tmpName = tempnam(sys_get_temp_dir(), 'data');
     $f1 = fopen($tmpName, 'w');
-    
+
     while($obj=$db->fetch_object($resql)) {
-    
+
         $obj->adresse1='';
         $obj->adresse2='';
         $obj->adresse3='';
         $obj->adresse4 = '';
-    
+
         list($obj->adresse1,$obj->adresse2,$obj->adresse3,$obj->adresse4) = explode("\n", $obj->address);
         unset($obj->address);
-        
+
         if($first) {
             $first = false;
             $THeader=array();
@@ -160,21 +160,21 @@ else if($action=='exportlist') {
             }
            fputcsv($f1, $THeader,";",'"');
         }
-        
+
         fputcsv($f1,  (array) $obj,";",'"');
     }
-  
+
     header('Content-Type: application/csv');
     header('Content-Disposition: attachment; filename=liste.csv');
     header('Pragma: no-cache');
-    
+
     readfile($tmpName);
-    
+
     exit;
 }
 
 
-if (GETPOST('clearlist'))
+if (GETPOST('clearlist', 'none'))
 {
 	// Chargement de la classe
 	$classname = "MailingTargets";
@@ -423,7 +423,7 @@ if ($object->fetch($id) >= 0)
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as soc ON (soc.rowid=socp.fk_soc)";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."socpeople_extrafields as socex ON (socp.rowid=socex.fk_object)";
         $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_civility as civ ON (civ.code=socp.civility)";
-        
+
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe_commerciaux as soccom ON soccom.fk_soc=socp.fk_soc";
 	//}
 	$sql .= " WHERE mc.fk_mailing=".$object->id;
@@ -660,11 +660,11 @@ if ($object->fetch($id) >= 0)
             print '<input type="hidden" name="sql" value="'.base64_encode($sql).'">';
             print '<input type="hidden" name="id" value="'.$object->id.'">';
             print '<input type="hidden" name="action" value="exportlist">';
-    
+
             print ''.$langs->trans("ExportList").': '.'<input type="submit" name="exportlist" class="button" value="'.$langs->trans("Export").'" />';
-            
+
             print '</form>';
-            
+
         }
 
 		$db->free($resql);


### PR DESCRIPTION
# FIX

A partir de la v12 le paramètre check de la fonction GETPOST est alphanohtml par défaut ce qui fait que tous nos inputs ayant une balise html sont vidés.

Modification (et typage) de tous les paramètres check manquants.