### PR TITLE
FIX : Page destinataire 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 
 ## 2.4 *26/10/2021*
+- FIX : Impossibilité de supprimé des contacts ajoutés en tant que destinataires + correction bugs - *01/06/2023* - 2.4.10
 - FIX : V17 Compat - *17/01/2023* - 2.4.9
 - FIX : V16 TOKEN - *08/06/2022* - 2.4.8
 - FIX : Gestion de l'affichage des extrafields sur une fiche sendinblue- 2.4.7 *16/06/2022*

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 
 ## 2.4 *26/10/2021*
-- FIX : Impossibilité de supprimé des contacts ajoutés en tant que destinataires + correction bugs - *01/06/2023* - 2.4.10
+- FIX : Impossibilité de supprimer des contacts ajoutés en tant que destinataires + correction bugs - *01/06/2023* - 2.4.10
 - FIX : V17 Compat - *17/01/2023* - 2.4.9
 - FIX : V16 TOKEN - *08/06/2022* - 2.4.8
 - FIX : Gestion de l'affichage des extrafields sur une fiche sendinblue- 2.4.7 *16/06/2022*

--- a/core/modules/modsendinblue.class.php
+++ b/core/modules/modsendinblue.class.php
@@ -60,7 +60,7 @@ class modsendinblue extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "SendinBlue Connector";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '2.4.9';
+		$this->version = '2.4.10';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/sendinblue/target.php
+++ b/sendinblue/target.php
@@ -343,7 +343,8 @@ if ($object->fetch($id) >= 0)
 				$qualified=1;
 				foreach ($obj->require_module as $key)
 				{
-					if (! empty($conf->$key->enabled) || (! $user->admin && $obj->require_admin))
+
+					if (empty($conf->$key->enabled) || (! $user->admin && $obj->require_admin))
 					{
 						$qualified=0;
 						//print "Les prerequis d'activation du module mailing ne sont pas respectes. Il ne sera pas actif";
@@ -628,7 +629,7 @@ if ($object->fetch($id) >= 0)
 					print '<td align="center">&nbsp;</td>';
 					print '<td align="right" class="nowrap">'.$langs->trans("MailingStatusNotSent");
 					if ($user->rights->mailing->creer && $allowaddtarget) {
-						print '<a href="'.$_SERVER['PHP_SELF'].'?action=delete&rowid='.$obj->rowid.$param.'">'.img_delete($langs->trans("RemoveRecipient"));
+						print '<a href="'.$_SERVER['PHP_SELF'].'?action=delete&rowid='.$obj->rowid.$param.'&token='.$_SESSION['newtoken'].'">'.img_delete($langs->trans("RemoveRecipient"));
 					}
 					print '</td>';
 				}

--- a/sendinblue/target.php
+++ b/sendinblue/target.php
@@ -629,7 +629,8 @@ if ($object->fetch($id) >= 0)
 					print '<td align="center">&nbsp;</td>';
 					print '<td align="right" class="nowrap">'.$langs->trans("MailingStatusNotSent");
 					if ($user->rights->mailing->creer && $allowaddtarget) {
-						print '<a href="'.$_SERVER['PHP_SELF'].'?action=delete&rowid='.$obj->rowid.$param.'&token='.$_SESSION['newtoken'].'">'.img_delete($langs->trans("RemoveRecipient"));
+						$newToken = function_exists('newToken') ? newToken() : $_SESSION['newtoken'];
+						print '<a href="'.$_SERVER['PHP_SELF'].'?action=delete&rowid='.$obj->rowid.$param.'&token='.$newToken.'">'.img_delete($langs->trans("RemoveRecipient"));
 					}
 					print '</td>';
 				}


### PR DESCRIPTION
## FIX : Page destinataire 

Correction de bugs multiples sur l'onglet "Destinataire" du module sendInBlue : 
- Problème de token sur suppression de contacts de la liste des destinataires déjà ajoutés 
- Pas d'affichage des solutions d'ajout de contacts lorsque les modules dont dépendent les solutions sont désactivés