### PR TITLE
FIX : DA023606 - Statut des destinataires 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 
 ## 2.4 *26/10/2021*
+- FIX : Status of mailing targets were not working - *29/06/2023* - 2.4.12
 - FIX : Make menu experimentals because they don't work - *20/06/2023* - 2.4.11
 - FIX : Impossibilité de supprimer des contacts ajoutés en tant que destinataires + correction bugs - *01/06/2023* - 2.4.10
 - FIX : V17 Compat - *17/01/2023* - 2.4.9

--- a/core/modules/modsendinblue.class.php
+++ b/core/modules/modsendinblue.class.php
@@ -60,7 +60,7 @@ class modsendinblue extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "SendinBlue Connector";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '2.4.11';
+		$this->version = '2.4.12';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/sendinblue/target.php
+++ b/sendinblue/target.php
@@ -416,7 +416,7 @@ if ($object->fetch($id) >= 0)
 	}
 
 	// List of selected targets
-	$sql  = "SELECT DISTINCT mc.rowid, mc.lastname,civ.label as civilite,mc.firstname, mc.email, mc.other, mc.statut
+	$sql  = "SELECT DISTINCT mc.rowid, mc.lastname,civ.label as civilite,mc.firstname, mc.email, mc.other, sendinblue_status as statut
 	,soc.nom as 'societe',socp.address
 	,socp.zip,socp.town,socp.phone,socp.phone_mobile, mc.date_envoi, mc.source_url, mc.source_id, mc.source_type";
 	$sql .= " FROM ".MAIN_DB_PREFIX."mailing_cibles as mc";


### PR DESCRIPTION
## FIX : DA023606 - Statut des destinataires  

Prise en compte du champ "sendinblue_statut" dans la requête de récupération des données, puisque c'est cette donnée qui est mise à jour par sendInBlue 
